### PR TITLE
Prevent honeypot and timetrap elements from creating empty html containers

### DIFF
--- a/src/views/honeypot.blade.php
+++ b/src/views/honeypot.blade.php
@@ -7,12 +7,12 @@
 </div>
 
 
+@if($errors)
 <div class="{{$config['divClass']}} @if($errors){{$config['errorClass']}} @endif">
-  @if($errors)
     <ul class="{{$config['errorMessageClass']}}">
         @foreach ($errors as $error)
         <li>{{$error}}</li>
         @endforeach
     </ul>
-  @endif
 </div>
+@endif

--- a/src/views/timetrap.blade.php
+++ b/src/views/timetrap.blade.php
@@ -7,12 +7,12 @@
 </div>
 
 
+@if($errors)
 <div class="{{$config['divClass']}} @if($errors){{$config['errorClass']}} @endif">
-  @if($errors)
     <ul class="{{$config['errorMessageClass']}}">
         @foreach ($errors as $error)
         <li>{{$error}}</li>
         @endforeach
     </ul>
-  @endif
 </div>
+@endif


### PR DESCRIPTION
I've noticed those two elements where creating empty `<div class=f"group"> </div>` even when there are no errors to display.

For example this code: `{!! Form::honeypot("unicorn_mail") !!}` would render:
```php
<div id="unicorn_mail_container" class="f-group">
    <input type="text" id="unicorn_mail" name="unicorn_mail" value="" autocomplete="off" tabindex="-1">
    <script>
      document.querySelector('#unicorn_mail_container').style.display = "none";
      document.querySelector('#unicorn_mail_container').setAttribute('aria-hidden', 'true');
    </script>
</div>


<div class="f-group ">
  </div>
```

**Problem**:
In cases where the `f-group` CSS class is used to add space between form elements, unwanted additional space created by those container.

**Solution suggested**: 
Wrap the said container into the `@if` condition to only render it when there are errors to display.


